### PR TITLE
Change from environment file to environment variable for API key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ npm-debug.log*
 # App specific
 env.sh
 openstates_cache.sqlite
+.influencetx-secrets.env
 
 # Unit test / coverage reports
 htmlcov/

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ pip-delete-this-directory.txt
 npm-debug.log*
 
 # App specific
-.influencetx-secrets.env
+env.sh
 openstates_cache.sqlite
 
 # Unit test / coverage reports

--- a/README_DEV.rst
+++ b/README_DEV.rst
@@ -50,9 +50,13 @@ API key to the secrets file.
 - You should receive an email with your new API key. Follow the activation link.
 - Copy your api key into the following command and run it in the root directory of the repo (i.e. where README.md is located)::
 
-    echo "OPENSTATES_API_KEY=YOUR-API-KEY-HERE" >> .influencetx-secrets.env
+    echo "export OPENSTATES_API_KEY=YOUR-API-KEY-HERE" >> env.sh
 
-Note that **changes to .influencetx-secrets.env should never be committed**.
+- Export environment variables using the new script::
+
+    source env.sh
+
+Note that **changes to ``env.sh`` should never be committed**.
 
 .. _Register for an Open States API key: https://openstates.org/api/register/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,7 @@ services:
     command: bash -exc "pip install -r requirements/local.txt && python3 manage.py migrate && python3 manage.py runserver 0.0.0.0:5120"
     environment:
       - DATABASE_URL=psql://postgres:mysecretpassword@postgres:5432/influencetx
-    env_file:
-      - .influencetx-secrets.env
+      - OPENSTATES_API_KEY=${OPENSTATES_API_KEY}
     volumes:
       - .:/usr/src/app
     ports:

--- a/influencetx/templates/openstates/api_key_required.html
+++ b/influencetx/templates/openstates/api_key_required.html
@@ -23,7 +23,13 @@
     Copy your api key into the following command and run it in the root directory of the repo
     (i.e. where README.md is located):
     <p>
-      <code>echo "OPENSTATES_API_KEY=YOUR-API-KEY-HERE" >> .influencetx-secrets.env</code>
+      <code>echo "export OPENSTATES_API_KEY=YOUR-API-KEY-HERE" >> env.sh</code>
+    </p>
+  </li>
+  <li>
+    Export environment variables using the new script:
+    <p>
+      <code>source env.sh</code>
     </p>
   </li>
 </ol>


### PR DESCRIPTION
Using an environment file with docker-compose causes docker to fail if the file is not present. Since we don't want to commit API keys to git, and we don't want to fail if a dev doesn't have an API key setup, an environment variable is a better solution.

@100stacks, @scichelli: I believe both of you have set this up with the old API-key config. Could you try this new configuration out on your system and review this PR?