### PR TITLE
46: Allow localhost, 127.0.0.1 in local ALLOWED_HOSTS

### DIFF
--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -71,4 +71,4 @@ TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
 # Your local stuff: Below this line define 3rd party library settings
 # ------------------------------------------------------------------------------
-ALLOWED_HOSTS = env.list('DJANGO_ALLOWED_HOSTS', default=['influencetx.com', 'api.influencetx.com'])
+ALLOWED_HOSTS = env.list('DJANGO_ALLOWED_HOSTS', default=['localhost', '127.0.0.1', 'influencetx.com', 'api.influencetx.com'])


### PR DESCRIPTION
This fixes an issue I encountered while getting started. The local config wasn't allowing `localhost` or `127.0.0.1` as allowed hosts.

This seems like a sane default to me for the development environment, so I added them directly to `local.py` rather than piping environment variables through `env.sh` -> `docker-compose.yml`, etc. Happy to change the approach if this isn't quite right!